### PR TITLE
add --skip-bundle option

### DIFF
--- a/lib/simba.rb
+++ b/lib/simba.rb
@@ -24,9 +24,11 @@ module Simba
     end
 
     def bundle_dependencies
-      say "Bundling application dependencies using bundler."
-      in_root do
-        run 'bundle install'
+      unless ARGV.include? '--skip-bundle' then
+        say "Bundling application dependencies using bundler."
+        in_root do
+          run 'bundle install'
+        end
       end
     end
   end


### PR DESCRIPTION
Hi, there

I love sinatra and sequel. It's so glad to see you release skeleton tool for sinatra.
In my projects with rails, sometime I use --skip-bundle to just have the skeleton, and adjust Gemfile and run bundle install myself.
So I add it to simba, hopefully you accept it.
