### PR TITLE
Use sprockets instead of sinatra-assetpack

### DIFF
--- a/lib/simba/base_app/Gemfile
+++ b/lib/simba/base_app/Gemfile
@@ -1,17 +1,24 @@
 source "https://rubygems.org"
 
 gem "slim"
-gem "sass"
 gem "sqlite3"
 gem "sequel"
 gem "sinatra"
-gem "coffee-script"
 gem "sinatra-contrib"
 gem "sinatra-flash"
-gem "sinatra-assetpack", :require => "sinatra/assetpack"
+gem "sprockets"
+gem "sprockets-helpers"
 
-group :development, :test do
+# If you want to use mail
+# gem "pony"
+
+group :development do
   gem "pry"
+  gem "sass"
+  gem "sprockets-sass"
+  gem "coffee-script"
+  gem "uglifier"
+  gem "capistrano"
 end
 
 group :production do
@@ -19,12 +26,8 @@ group :production do
 end
 
 group :test do
+  gem "pry"
   gem "rack-test"
   gem "factory_girl"
   gem "database_cleaner"
-end
-
-group :deploy do
-  gem "uglifier"
-  gem "capistrano"
 end

--- a/lib/simba/base_app/Rakefile
+++ b/lib/simba/base_app/Rakefile
@@ -1,7 +1,2 @@
 # load rake tasks
 Dir["./lib/tasks/**/*.rake"].sort.each { |ext| load ext }
-
-# load assetpacket tasks
-APP_FILE  = './config/boot.rb'
-APP_CLASS = 'Sinatra::Application'
-require 'sinatra/assetpack/rake'

--- a/lib/simba/base_app/config/assets.rb
+++ b/lib/simba/base_app/config/assets.rb
@@ -1,0 +1,43 @@
+module Assets
+  App = Sprockets::Environment.new
+  App.append_path File.expand_path(File.dirname(__FILE__) + '/../app/assets')
+
+  Sprockets::Helpers.configure do |config|
+    config.environment = App
+    config.prefix = ''
+    config.digest = true
+
+    manifest = File.dirname(__FILE__) + '/../public/manifest.json'
+    if ENV['RACK_ENV'] != 'development' and File.exist?(manifest)
+      config.manifest = Sprockets::Manifest.new App, manifest
+    end
+  end
+
+  class Middleware
+    def initialize app
+      @app = app
+    end
+
+    def call env
+      if env['PATH_INFO'] =~ /^\/(js|css|img)\//
+        App.call env
+      else
+        @app.call env
+      end
+    end
+  end
+
+  module Helpers
+    extend Sprockets::Helpers
+
+    def css file
+      file = "css/#{file}.css"
+      %Q|<link rel='stylesheet' href='#{Helpers.asset_path file}'/>|
+    end
+
+    def js file
+      file = "js/#{file}.js"
+      %Q|<script src='#{Helpers.asset_path file}'></script>|
+    end
+  end
+end

--- a/lib/simba/base_app/config/boot.rb.tt
+++ b/lib/simba/base_app/config/boot.rb.tt
@@ -21,18 +21,8 @@ if development?
   also_reload "lib/**/*.rb", "app/{models,helpers}/**/*.rb"
 end
 
-# assetpack support
-assets do
-  serve "/js", :from => "app/assets/js"
-  serve "/css", :from => "app/assets/css"
-  serve "/img", :from => "app/assets/img"
-
-  css_compression :sass
-  js_compression  :uglify
-
-  js :application, ["/js/*.js"]
-  css :application, ["/css/*.css"]
-end
+# assets
+require settings.root + "/config/assets.rb"
 
 # require project files
 Dir.glob "./{lib,app/models,app/helpers,app/controllers}/**/*.rb" do |f|

--- a/lib/simba/base_app/lib/tasks/assets.rake
+++ b/lib/simba/base_app/lib/tasks/assets.rake
@@ -1,0 +1,20 @@
+require 'rake/sprocketstask'
+require 'coffee-script'
+require 'sass'
+require 'sprockets-sass'
+require 'sprockets-helpers'
+require File.dirname(__FILE__) + '/../../config/assets.rb'
+
+Rake::SprocketsTask.new do |t|
+  t.environment = Assets::App
+  t.output = "./public"
+  t.assets = begin
+    img_assets = Dir.glob('app/assets/img/**/*.*')
+    css_assets = Dir.glob('app/assets/css/*.{sass,less,css}').map{|f| f.sub /#{File.extname f}$/, '.css'}
+    js_assets  = Dir.glob('app/assets/js/*.{coffee,js}').map{|f| f.sub /#{File.extname f}$/, '.js'}
+    (img_assets + css_assets + js_assets).select do |f|
+      f.sub! 'app/assets/', ''
+      ! File.basename(f).start_with?('_')
+    end
+  end
+end


### PR DESCRIPTION
Bonus benefits: no need to load sass / coffee in production env any more, thus we can save some memory before Ruby 2.0's GC improvement on COW memory.

NOTE production env requires `public/manifest.json`. When deploying, should run `rake assets clean_assets` first. Document also needed.

NOTE sprockets is not happy with `@import` statements in SASS, and sprockets-sass fixes it. But we should keep watching the code of sprockets and lessen dependency if possible.

TODO instructions / caveats on assets and web-servers configs are needed.

TODO custom asset compressor.

TODO make some of the gems optional.. ?
